### PR TITLE
aws成分をファイル切り出し

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@
 ## TypeScriptのコードの書き方
 * 変数や引数にはanyやunknownではない具体的な型を指定してください
 * letやvarではなくconstを使用できるようなコードにしてください。またArrayに対するpushやpopなどの変更を伴うメソッドの仕様も避けてください
+* AWS SDKが提供する型に起因する属性がoptionalかつ xx|undefined である場合、その値の利用先では積極的に attribute! を使用してoptional成分を排除してください
 
 ## AWS SDKのコードの書き方
 * paginate系のメソッドを使用する場合は、paginatorを使用してください

--- a/app/aws.ts
+++ b/app/aws.ts
@@ -1,0 +1,120 @@
+import {
+	CloudWatchLogsClient,
+	paginateFilterLogEvents,
+	type FilteredLogEvent,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+	DescribeTaskDefinitionCommand,
+	DescribeTasksCommand,
+	ECSClient,
+	paginateListTasks,
+	type Task,
+	type TaskDefinition,
+} from "@aws-sdk/client-ecs";
+
+/**
+ * 指定したECSクラスター内の全てのタスクARN（RUNNING, PENDING, STOPPED）を取得します。
+ * AWS SDKのpaginatorを利用して、全てのページからタスクARNを収集します。
+ *
+ * @param clusterName - 対象のECSクラスター名
+ * @returns Promise<string[]> - 全てのタスクARNの配列
+ */
+export async function listEcsTaskArns(clusterName: string): Promise<string[]> {
+	const STATUSES = ["RUNNING", "PENDING", "STOPPED"] as const;
+	const allTaskArnsPromises = STATUSES.map(async (status) => {
+		const paginator = paginateListTasks(
+			{ client: ecsClient(), pageSize: 100 },
+			{ cluster: clusterName, desiredStatus: status },
+		);
+
+		const arns: string[] = [];
+		for await (const page of paginator) arns.push(...(page.taskArns ?? []));
+
+		return arns;
+	});
+
+	return (await Promise.all(allTaskArnsPromises)).flat();
+}
+
+/**
+ * 指定したECSタスクARN配列に対応するタスク情報を取得します。全てのARNが同一クラスタに属すると仮定します。
+ *
+ * @param arns - 取得対象のECSタスクARNの配列
+ * @returns Promise<Task[]> - タスク情報の配列（存在しない場合は空配列）
+ */
+export async function describeTasks(arns: string[]): Promise<Task[]> {
+	if (arns.length === 0) return [];
+
+	const cluster = arns[0].split("/")[1]; // arnsはすべて同じクラスタに属すると見做し、1つ目からクラスタ名を取り出す
+	const tasks = await ecsClient()
+		.send(new DescribeTasksCommand({ cluster, tasks: arns }))
+		.then((descRes) => descRes.tasks ?? []);
+
+	return tasks as Task[];
+}
+
+export async function describeTaskDefinitions(
+	arns: string[],
+): Promise<TaskDefinition[]> {
+	const raws = arns.map(
+		async (arn: string) =>
+			await ecsClient()
+				.send(new DescribeTaskDefinitionCommand({ taskDefinition: arn }))
+				.then((res) => res.taskDefinition),
+	);
+
+	const defs = (await Promise.all(raws)).filter((def) => def !== undefined);
+
+	return defs as TaskDefinition[];
+}
+
+function ecsClient() {
+	return new ECSClient({});
+}
+
+export async function filterLogEvents(
+	logGroupName: string,
+	startTime: number,
+): Promise<FilteredLogEvent[]> {
+	const paginator = paginateFilterLogEvents(
+		{ client: new CloudWatchLogsClient({}) },
+		{ logGroupName, startTime },
+	);
+
+	const events: FilteredLogEvent[] = [];
+	for await (const page of paginator) events.push(...(page.events ?? []));
+
+	return events;
+}
+
+export type EcsTaskStateChangeEvent = {
+	version: string;
+	id: string;
+	"detail-type": string;
+	source: string;
+	account: string;
+	time: string;
+	region: string;
+	detail: Task; // ここ多分Taskであってると思う。確証は無い
+};
+
+export function getLogStream(
+	taskdef: TaskDefinition,
+	taskId: string,
+	containerName: string,
+) {
+	const appContainer = taskdef.containerDefinitions?.find(
+		(container) => container.name === containerName,
+	);
+	if (!appContainer) return;
+
+	const log = appContainer.logConfiguration!;
+	if (log.logDriver !== "awslogs") return;
+
+	const prefix = log.options?.["awslogs-stream-prefix"] || "";
+
+	return {
+		group: log.options?.["awslogs-group"]!,
+		stream: `${prefix}/${containerName}/${taskId}`,
+	};
+}

--- a/app/routes/ecslog.tsx
+++ b/app/routes/ecslog.tsx
@@ -1,192 +1,65 @@
-// ## ページ仕様:
-// AWS APIを使い、Cloudwatch Logsに記録されたECSタスク終了イベントの一覧を表示する
-//
-// ### データ取得方法
-// - 指定したロググループに "detail-type": "ECS Task State Change" のイベントが記録されていることを前提とする
-// - ロググループ名は環境変数LOG_GROUP_NAMEから取得する
-// - ログエントリは直近24時間分とする
-// - ログエントリのうち、startedByが "ecs-svc/" で始まるものは除外する
-//
-// ### 表示内容
-// 下記をtable表示する。スタイルは一旦はごくシンプルなものとする。
-// - タスク定義のfamily名
-// - containerOverridesにあるappコンテナの実行コマンド
-// - タスクの開始時刻
-// - タスクの終了時刻とタスク実行にかかった時間 (開始-終了)
-// - ログエントリの"message"フィールドをJSON pretty printしたもの
-
-import {
-	CloudWatchLogsClient,
-	type FilteredLogEvent,
-	paginateFilterLogEvents,
-} from "@aws-sdk/client-cloudwatch-logs";
 import { type LoaderFunctionArgs, useLoaderData } from "react-router";
+import { filterLogEvents, type EcsTaskStateChangeEvent } from "~/aws";
 
 // ロググループ名は環境変数から取得
 const LOG_GROUP_NAME = process.env.LOG_GROUP_NAME ?? "";
 
-// ECSタスク状態変更イベントの型定義
-interface EcsTaskStateChangeEvent {
-	version?: string;
-	id?: string;
-	"detail-type"?: string;
-	source?: string;
-	account?: string;
-	time?: string;
-	region?: string;
-	detail?: {
-		clusterArn?: string;
-		containerInstanceArn?: string;
-		containers?: Array<{
-			containerArn?: string;
-			lastStatus?: string;
-			name?: string;
-			taskArn?: string;
-		}>;
-		createdAt?: string;
-		desiredStatus?: string;
-		group?: string;
-		lastStatus?: string;
-		startedAt?: string;
-		stoppedAt?: string;
-		startedBy?: string;
-		taskArn?: string;
-		taskDefinitionArn?: string;
-		overrides?: {
-			containerOverrides?: Array<{
-				name?: string;
-				command?: string[];
-			}>;
-		};
-	};
-}
-
 // 表示用データの型定義
 interface DisplayEvent {
-	eventId?: string;
-	family?: string;
+	eventId: string;
+	family: string;
 	appCommand?: string;
-	startedAt?: string;
-	stoppedAt?: string;
+	startedAt: Date;
+	stoppedAt: Date;
 	durationSec?: number;
 	prettyMessage: string;
 }
 
-// ログエントリをAPIで取得する関数
-async function fetchRawEvents(
-	logGroupName: string,
-	limit = 200,
-): Promise<FilteredLogEvent[]> {
-	const client = new CloudWatchLogsClient({});
+// 表示用データへ加工する関数
+function mapEventToDisplay(e: EcsTaskStateChangeEvent): DisplayEvent {
+	const detail = e.detail;
 
-	// 全ログだと時間がかかりすぎるので、直近24hに限定
-	const startTime = new Date().getTime() - 24 * 60 * 60 * 1000;
+	// containerOverridesからappコンテナのコマンドを取得
+	let appCommand: string | undefined = undefined;
+	const overrides = detail.overrides?.containerOverrides;
+	if (overrides) {
+		const appContainer = overrides.find(
+			(container) => container.name === "app",
+		);
+		if (appContainer?.command) {
+			appCommand = appContainer.command.join(" ");
+		}
+	}
 
-	const paginator = paginateFilterLogEvents(
-		{ client },
-		{
-			logGroupName,
-			startTime,
-			limit: 50,
-		},
+	const startedAt = detail.startedAt!;
+	const stoppedAt = detail.stoppedAt!;
+
+	const durationSec = Math.round(
+		(new Date(stoppedAt).getTime() - new Date(startedAt).getTime()) / 1000,
 	);
 
-	const allEvents: FilteredLogEvent[] = [];
-	for await (const page of paginator) {
-		if (page.events) {
-			const newEvents = [...allEvents, ...page.events];
-			if (newEvents.length >= limit) {
-				return newEvents.slice(0, limit);
-			}
-			allEvents.splice(0, allEvents.length, ...newEvents);
-		}
-	}
-
-	return allEvents;
-}
-
-// 表示用データへ加工する関数
-function mapEventToDisplay(event: FilteredLogEvent): DisplayEvent {
-	let msgObj: EcsTaskStateChangeEvent | null = null;
-	let pretty = "";
-
-	try {
-		msgObj = JSON.parse(event.message ?? "") as EcsTaskStateChangeEvent;
-		pretty = JSON.stringify(msgObj, null, 2);
-	} catch {
-		pretty = event.message ?? "";
-	}
-
-	// family名
-	let family: string | undefined = undefined;
-	// appコンテナのコマンド
-	let appCommand: string | undefined = undefined;
-	// 開始・終了時刻
-	let startedAt: string | undefined = undefined;
-	let stoppedAt: string | undefined = undefined;
-	let durationSec: number | undefined = undefined;
-
-	if (msgObj?.detail) {
-		const detail = msgObj.detail;
-
-		// taskDefinitionArnからfamily名を抽出
-		if (detail.taskDefinitionArn) {
-			const arnParts = detail.taskDefinitionArn.split(":task-definition/");
-			if (arnParts.length > 1) {
-				family = arnParts[1].split(":")[0];
-			}
-		}
-
-		// containerOverridesからappコンテナのコマンドを取得
-		const overrides = detail.overrides?.containerOverrides;
-		if (overrides) {
-			const appContainer = overrides.find(
-				(container) => container.name === "app",
-			);
-			if (appContainer?.command) {
-				appCommand = appContainer.command.join(" ");
-			}
-		}
-
-		// 開始・終了時刻と実行時間を計算
-		startedAt = detail.startedAt;
-		stoppedAt = detail.stoppedAt;
-
-		if (startedAt && stoppedAt) {
-			const startTime = new Date(startedAt).getTime();
-			const stopTime = new Date(stoppedAt).getTime();
-			if (!Number.isNaN(startTime) && !Number.isNaN(stopTime)) {
-				durationSec = Math.round((stopTime - startTime) / 1000);
-			}
-		}
-	}
-
 	return {
-		eventId: event.eventId,
-		family,
+		eventId: e.id,
+		family: detail.group!,
 		appCommand,
 		startedAt,
 		stoppedAt,
 		durationSec,
-		prettyMessage: pretty,
+		prettyMessage: JSON.stringify(e),
 	};
 }
 
 export async function loader(args: LoaderFunctionArgs) {
-	const rawEvents = await fetchRawEvents(LOG_GROUP_NAME, 200);
+	const rawEvents = (
+		await filterLogEvents(
+			LOG_GROUP_NAME,
+			Date.now() - 24 * 60 * 60 * 1000, // 直近24時間分のログを取得
+		)
+	).map((log) => JSON.parse(log.message!) as EcsTaskStateChangeEvent);
 
 	// startedByが "ecs-svc/" で始まるものを除外
 	const filteredEvents = rawEvents.filter((event) => {
-		try {
-			const msgObj = JSON.parse(event.message ?? "") as EcsTaskStateChangeEvent;
-			const startedBy = msgObj?.detail?.startedBy;
-			return !(
-				typeof startedBy === "string" && startedBy.startsWith("ecs-svc/")
-			);
-		} catch {
-			// パースできない場合は除外しない
-			return true;
-		}
+		return !event.detail.startedBy?.startsWith("ecs-svc/");
 	});
 
 	const events = filteredEvents.map(mapEventToDisplay);
@@ -225,14 +98,10 @@ export default function Ecslog() {
 								{event.appCommand ?? "-"}
 							</td>
 							<td className="border px-2 py-1 align-top">
-								{event.startedAt
-									? new Date(event.startedAt).toLocaleString()
-									: "-"}
+								{event.startedAt ? event.startedAt.toLocaleString() : "-"}
 							</td>
 							<td className="border px-2 py-1 align-top">
-								{event.stoppedAt
-									? new Date(event.stoppedAt).toLocaleString()
-									: "-"}
+								{event.stoppedAt ? event.stoppedAt.toLocaleString() : "-"}
 							</td>
 							<td className="border px-2 py-1 align-top">
 								{event.durationSec ?? "-"}

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,153 +1,49 @@
-// ## ページ仕様:
-// AWS APIを使い、取得できるECSタスクの詳細情報一覧を表示する。
-//
-// ### データ取得方法
-// - listTasksとdescribeTasksを使用して、取得できるタスクすべての詳細情報を取得する
-// - クラスタ名は環境変数CLUSTER_NAMEから取得する
-// - タスクのステータスは、RUNNING, PENDING, STOPPEDのすべてを対象とする
-// - タスク詳細情報に紐づいたタスク定義のrevisionも取得する
-//
-// ### 表示内容
-// 下記をtable表示する。スタイルは一旦はごくシンプルなものとする。
-// - ECSクラスタ
-// - タスクID
-// - タスク開始時刻
-// - タスクステータス
-// - 各コンテナの実行コマンド(containerOverridesが存在する場合のみ。コマンドはoverridesから取得)
-// - タスク定義のfamily名
-// - appコンテナのロググループ名
-// - appコンテナのログストリームのname
-
-import {
-	type ContainerOverride,
-	DescribeTaskDefinitionCommand,
-	DescribeTasksCommand,
-	ECSClient,
-	type Task,
-	type TaskDefinition,
-	paginateListTasks,
-} from "@aws-sdk/client-ecs";
+import type { TaskDefinition } from "@aws-sdk/client-ecs";
 import type { Container } from "@aws-sdk/client-ecs";
 import { type LoaderFunctionArgs, useLoaderData } from "react-router";
+import {
+	describeTaskDefinitions,
+	describeTasks,
+	getLogStream,
+	listEcsTaskArns,
+} from "~/aws";
 
 // クラスタ名は環境変数から取得
 const CLUSTER_NAME = process.env.CLUSTER_NAME ?? "";
-const STATUSES = ["RUNNING", "PENDING", "STOPPED"] as const;
 
 // Loader (SSR)
 export async function loader(args: LoaderFunctionArgs) {
-	const client = new ECSClient({});
+	const allTaskArns = await listEcsTaskArns(CLUSTER_NAME);
+	const taskDetails = await describeTasks(allTaskArns);
 
-	// 各ステータスごとにlistTasksを並列実行し、結果をまとめる
-	const allTaskArnsPromises = STATUSES.map(
-		async (status): Promise<string[]> => {
-			const paginator = paginateListTasks(
-				{
-					client,
-					pageSize: 100,
-				},
-				{
-					cluster: CLUSTER_NAME,
-					desiredStatus: status,
-				},
-			);
+	const taskDefArns = [
+		...new Set(taskDetails.map((task) => task.taskDefinitionArn)),
+	] as string[];
 
-			const taskArnsArrays: string[][] = [];
-			for await (const page of paginator) {
-				const pageArns = page.taskArns ?? [];
-				taskArnsArrays.push(pageArns);
-			}
-
-			return taskArnsArrays.flat();
-		},
+	const taskDefs = new Map<string, TaskDefinition>(
+		(await describeTaskDefinitions(taskDefArns)).map((d) => [
+			d.taskDefinitionArn!,
+			d,
+		]),
 	);
 
-	const allTaskArnsArrays = await Promise.all(allTaskArnsPromises);
-	const allTaskArns = allTaskArnsArrays.flat();
-
-	// describeTasksは100件ずつ処理
-	const taskDetailPromises: Promise<Task[]>[] = [];
-	for (let i = 0; i < allTaskArns.length; i += 100) {
-		const arns = allTaskArns.slice(i, i + 100);
-		if (arns.length === 0) continue;
-
-		const promise = client
-			.send(
-				new DescribeTasksCommand({
-					cluster: CLUSTER_NAME,
-					tasks: arns,
-				}),
-			)
-			.then((descRes) => descRes.tasks ?? []);
-
-		taskDetailPromises.push(promise);
-	}
-
-	const taskDetailArrays = await Promise.all(taskDetailPromises);
-	const taskDetails = taskDetailArrays.flat();
-
-	// タスク定義ARNを重複除去
-	const taskDefinitionArns = [
-		...new Set(
-			taskDetails
-				.map((task) => task.taskDefinitionArn)
-				.filter((arn): arn is string => arn !== undefined),
-		),
-	];
-
-	// タスク定義を並列取得
-	const taskDefinitionPromises = taskDefinitionArns.map(async (arn: string) => {
-		const taskDefRes = await client.send(
-			new DescribeTaskDefinitionCommand({
-				taskDefinition: arn,
-			}),
-		);
-		return { arn, taskDefinition: taskDefRes.taskDefinition };
-	});
-
-	const taskDefinitionResults = await Promise.all(taskDefinitionPromises);
-	const taskDefinitions = new Map<string, TaskDefinition>(
-		taskDefinitionResults
-			.filter(
-				(result): result is { arn: string; taskDefinition: TaskDefinition } =>
-					result.taskDefinition !== undefined,
-			)
-			.map((result) => [result.arn, result.taskDefinition]),
-	);
-
-	const data = taskDetails.map((task): TaskData => {
+	const data = taskDetails.map((task) => {
 		// containerOverridesのマップを作成
 		const overrideMap = new Map<string, string[]>(
-			(task.overrides?.containerOverrides ?? [])
-				.filter(
-					(o): o is ContainerOverride & { name: string; command: string[] } =>
-						o.name !== undefined && o.command !== undefined,
-				)
-				.map((o) => [o.name, o.command]),
+			(task.overrides!.containerOverrides ?? [])
+				.filter((o) => o.command)
+				.map((o) => [o.name!, o.command!]),
 		);
 
 		// タスク定義情報を取得
-		const taskDefinition = task.taskDefinitionArn
-			? taskDefinitions.get(task.taskDefinitionArn)
-			: undefined;
-		const revision = task.taskDefinitionArn?.split(":").pop();
+		const taskDefinition = taskDefs.get(task.taskDefinitionArn!);
+		const revision = task.taskDefinitionArn!.split(":").pop();
 
-		// appコンテナのロググループ名とログストリーム名を取得
-		const appContainer = taskDefinition?.containerDefinitions?.find(
-			(container) => container.name === "app",
+		const stream = getLogStream(
+			taskDefinition!,
+			task.taskArn!.split("/").pop()!,
+			"app",
 		);
-		const appLogGroup =
-			appContainer?.logConfiguration?.logDriver === "awslogs"
-				? (appContainer.logConfiguration.options?.["awslogs-group"] ?? "")
-				: "";
-
-		const taskId = task.taskArn?.split("/").pop();
-		const appLogStreamName =
-			appLogGroup &&
-			taskId &&
-			appContainer?.logConfiguration?.options?.["awslogs-stream-prefix"]
-				? `${appContainer.logConfiguration.options["awslogs-stream-prefix"]}/app/${taskId}`
-				: "";
 
 		return {
 			clusterArn: task.clusterArn,
@@ -158,8 +54,8 @@ export async function loader(args: LoaderFunctionArgs) {
 				?.split(":task-definition/")[1]
 				?.split(":")[0],
 			revision: revision,
-			appLogGroup: appLogGroup,
-			appLogStreamName: appLogStreamName,
+			appLogGroup: stream?.group,
+			appLogStreamName: stream?.stream,
 			containers: (task.containers ?? []).map((c: Container) => ({
 				name: c.name,
 				command: c.name ? overrideMap.get(c.name) : undefined,
@@ -170,20 +66,18 @@ export async function loader(args: LoaderFunctionArgs) {
 	return { tasks: data };
 }
 
-type TaskData = {
-	clusterArn?: string;
-	taskArn?: string;
-	startedAt?: Date;
-	lastStatus?: string;
-	family?: string;
-	revision?: string;
-	appLogGroup?: string;
-	appLogStreamName?: string;
-	containers: Array<{ name?: string; command?: string[] }>;
-};
-
 type LoaderData = {
-	tasks: TaskData[];
+	tasks: {
+		clusterArn?: string;
+		taskArn?: string;
+		startedAt?: Date;
+		lastStatus?: string;
+		family?: string;
+		revision?: string;
+		appLogGroup?: string;
+		appLogStreamName?: string;
+		containers: Array<{ name?: string; command?: string[] }>;
+	}[];
 };
 
 export default function Home() {

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,0 @@
-{
-	"files": {
-		"include": ["/*", "app/**/*"],
-		"ignore": [".react-router/**/*"]
-	}
-}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,16 @@
+{
+	"files": {
+		"include": ["/*", "app/**/*"],
+		"ignore": [".react-router/**/*"]
+	},
+	"linter": {
+		"rules": {
+			"style": {
+				// sdk提供の型や仮で作った型など、optional情報が壊れている型を多用せざるを得ないが
+				// それを使う際に変に ?? "" などすると半端に壊れない値を取り出せてしまうので、
+				// 利用先で問題がハッキリするようにランタイムはundefのままにする。
+				"noNonNullAssertion": "off"
+			}
+		}
+	}
+}


### PR DESCRIPTION
aws sdkでデータを取り出す部分をlib的に別ファイルに切り出した。
一旦、ファイル構造とかそういうのは気にせず、view (page/loader) から切り離す、というところに焦点。

切り出したついでに、各ページのコードはちょっと整理してある（手動）。主に型のoptionalの観点。
ただ明らかにアレな部分しかしてないので、コメントの有無など含めそこまでやりきってない。

---

ここで、nodeのaws sdkは型が半分死んでいるという問題が発覚した。
これについては方針がいくつか考えられたが、結局は「基本そのまま使う、利用側でattribute!で潰す」という方針にした。

他考えたものは以下：
* 型ユーティリティを作り、全属性optionalと|undefを消した型を作って使う
  - 割といけるのだが、構造体の子要素が構造体の場合、そこまでカバー出来ない。それをちゃんとやるのはこのアプローチでは難しい
    - `Task { ..., container: Container }` でContainerがまたundef地獄、みたいなパターン
* 型ユーティリティを作り、requiredとわかってるものだけrequiredに変換するようにして、その型を使う
  - 上と概ね同じ。全属性やるとちょっと乱暴だよね、という程度の差
  - 属性を指定するならうまいことやればランタイム実在チェックもできる
  - が、まぁ結局↑の案と同じデメリットがある
* 型定義ファイルをほぼまるっとコピーしてきて、手動でoptionalと|undefを消した型定義を作る
  - 昨今ならcopilotなりエディタの一括変換なりで案外いけそう
  - （↑でも同じだが）lib成分のコードでその型に変換する際に結局attr!する必要がある。また属性数がめっちゃ多いので、そのマッピングコードもなかなか多くなる
* 型とバリデーション系のライブラリを入れてなんかやる
  - （そこまで考えてないが）
  - 型がでかいので定義がだるい
  - そもそも、どうせ各属性についてrequiredなのかoptionalなのかって判断むずいし、現実的に行き当たりばったりするしかなくね？という気付き
    - APIの戻り値くらいならある程度あるが、ユースケースを絞れば実質こっちに倒れるとか、EventBridgeのイベントとかはドキュメントにもそんなにはっきり書いてない、とか

最終的には、最後に書いた「結局required/optionalの真偽ってわからんよな」が大きく、じゃあどこで潰してもあんま変わらんので、一番手間（追加コード）が少ない都度潰しでいいんじゃね、ということにした。

タイミング的に、地盤整備よりも動くものに時間かけたいというのも大きい。