### PR TITLE
デフォルトの終了タスク一覧の数を減らして高速化しつつ、過去にも遡れるようにする

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -18,13 +18,25 @@ export async function loader({
 	request,
 }: LoaderFunctionArgs): Promise<LoaderData> {
 	const envConfig = getCurrentEnvironmentConfig();
+	const { hours } = parseRequest(request);
 
-	const from = Date.now() - 24 * 60 * 60 * 1000; // 直近24時間分。ただちょっと多すぎてページ重いので、できればpaginateとかしたい
+	const from = Date.now() - (hours ?? 12) * 60 * 60 * 1000;
 
 	return {
 		currentTasks: await currentTasks(envConfig.cluster_name),
 		finishedTasks: await finishedTasks(envConfig.log_group_name, from),
 		clusterName: envConfig.cluster_name,
+	};
+}
+
+function parseRequest(request: Request): { hours?: number } {
+	const { searchParams: query } = new URL(request.url);
+
+	const hoursParam = query.get("hours");
+	const hours = hoursParam ? Number.parseInt(hoursParam, 10) : undefined;
+
+	return {
+		hours,
 	};
 }
 

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -4,6 +4,7 @@ import {
 	useLoaderData,
 	Link,
 	type HeadersArgs,
+	useSearchParams,
 } from "react-router";
 import {
 	describeTasks,
@@ -120,9 +121,14 @@ type LoaderData = {
 export default function Home() {
 	const { currentTasks, finishedTasks, clusterName } =
 		useLoaderData<LoaderData>();
+	const [searchParams] = useSearchParams();
 
 	const finishedTaskGroups = groupTasksByStoppedDate(finishedTasks);
 	const finishedTaskGroupKeys = Object.keys(finishedTaskGroups);
+
+	const currentHours = searchParams.get("hours");
+	const currentHoursNum = currentHours ? Number.parseInt(currentHours, 10) : 12;
+	const nextHours = currentHoursNum + 12;
 
 	return (
 		<div className="p-4">
@@ -269,6 +275,14 @@ export default function Home() {
 						])}
 					</tbody>
 				</table>
+			</div>
+			<div className="mt-4 text-center" id="load-more-button">
+				<Link
+					to={`/?hours=${nextHours}#load-more-button`}
+					className="inline-block px-3 py-1 text-sm text-gray-600 border border-gray-300 rounded hover:bg-gray-50 hover:border-gray-400 transition-colors"
+				>
+					更に12時間遡る
+				</Link>
 			</div>
 		</div>
 	);

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -5,6 +5,7 @@ import {
 	Link,
 	type HeadersArgs,
 	useSearchParams,
+	useNavigation,
 } from "react-router";
 import {
 	describeTasks,
@@ -122,6 +123,7 @@ export default function Home() {
 	const { currentTasks, finishedTasks, clusterName } =
 		useLoaderData<LoaderData>();
 	const [searchParams] = useSearchParams();
+	const navigation = useNavigation();
 
 	const finishedTaskGroups = groupTasksByStoppedDate(finishedTasks);
 	const finishedTaskGroupKeys = Object.keys(finishedTaskGroups);
@@ -129,6 +131,7 @@ export default function Home() {
 	const currentHours = searchParams.get("hours");
 	const currentHoursNum = currentHours ? Number.parseInt(currentHours, 10) : 12;
 	const nextHours = currentHoursNum + 12;
+	const isLoading = navigation.state === "loading";
 
 	return (
 		<div className="p-4">
@@ -281,7 +284,11 @@ export default function Home() {
 					to={`/?hours=${nextHours}#load-more-button`}
 					className="inline-block px-3 py-1 text-sm text-gray-600 border border-gray-300 rounded hover:bg-gray-50 hover:border-gray-400 transition-colors"
 				>
-					更に12時間遡る
+					{isLoading ? (
+						<span className="inline-block w-3 h-3 border border-gray-400 border-t-transparent rounded-full animate-spin" />
+					) : (
+						"更に12時間遡る"
+					)}
 				</Link>
 			</div>
 		</div>


### PR DESCRIPTION
なんかうまいことキャッシュするとか、取得済データは取らないように取得期間をうまいことゴニョゴニョするとかも考えたけど、
* イマイチ確実にならない（時間ベースだからかぶるとかかぶらないとかある）
  - ユースケース的に、1行無いのが結構問題というか厄介なので、そういう可能性は避けたい
* ぶっちゃけ過去を見るのそんな頻度じゃない
  - だいたい直近のエラーのが見れればokみたいなところある
* 「重めの処理をしてるはずだ」という意識があった上なら、（そこそこ遡っても）そんな待てない遅さではない

ということで、愚直に範囲内データを全部とる実装にした。

そのへんも含めて、ある程度機能は用意しつつ最低限の実装に留めた。
てかtailwindのanimate-spinは感動した